### PR TITLE
Add image_file specification for common image formats. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Currently, **takane** provides validators for the following objects:
   [1.0](https://github.com/ArtifactDB/takane/tree/gh-pages/docs/specifications/gff_file/1.0.md).
 - `gmt_file`:
   [1.0](https://github.com/ArtifactDB/takane/tree/gh-pages/docs/specifications/gmt_file/1.0.md).
+- `image_file`:
+  [1.0](https://github.com/ArtifactDB/takane/tree/gh-pages/docs/specifications/image_file/1.0.md).
 - `multi_sample_dataset`:
   [1.0](https://github.com/ArtifactDB/takane/tree/gh-pages/docs/specifications/multi_sample_dataset/1.0.md).
 - `ranged_summarized_experiment`:

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Currently, **takane** provides validators for the following objects:
   [1.0](https://github.com/ArtifactDB/takane/tree/gh-pages/docs/specifications/spatial_experiment/1.0.md),
   [1.1](https://github.com/ArtifactDB/takane/tree/gh-pages/docs/specifications/spatial_experiment/1.1.md),
   [1.2](https://github.com/ArtifactDB/takane/tree/gh-pages/docs/specifications/spatial_experiment/1.2.md).
+  [1.3](https://github.com/ArtifactDB/takane/tree/gh-pages/docs/specifications/spatial_experiment/1.3.md).
 - `string_factor`:
   [1.0](https://github.com/ArtifactDB/takane/tree/gh-pages/docs/specifications/string_factor/1.0.md).
 - `summarized_experiment`:

--- a/docs/specifications/_build.R
+++ b/docs/specifications/_build.R
@@ -7,7 +7,7 @@ known.variants <- list(
     dense_array.Rmd="1.1",
     data_frame.Rmd="1.1",
     simple_list.Rmd="1.1",
-    spatial_experiment.Rmd=c("1.1", "1.2")
+    spatial_experiment.Rmd=c("1.1", "1.2", "1.3")
 )
 
 dest <- "compiled"

--- a/docs/specifications/image_file.Rmd
+++ b/docs/specifications/image_file.Rmd
@@ -1,0 +1,37 @@
+```{r, results="hide", echo=FALSE}
+knitr::opts_chunk$set(error=FALSE)
+if (!exists(".version")) {
+    .version <- package_version("1.0")
+}
+```
+
+```{r, results="asis", echo=FALSE}
+cat("# Image file (", as.character(.version), ")", sep="")
+```
+
+## Overview
+
+The `image_file` format specifies the expected representation for an image file in one of the standard formats.
+
+## Object metadata
+
+The `OBJECT` file should contain a `bam_file` property, itself a JSON object with the following properties:
+
+- `version`, a string specifying the version of the `bam_file` format.
+```{r, results="asis", echo=FALSE}
+cat("  This should be set to \"", as.character(.version), "\".", sep="")
+```
+- `format`, a string specifying the format of the file.
+  This may be one of `"PNG"`, `"TIFF"`, `"JPEG"`, `"GIF"` or `"WEBP"`.
+
+## Directory structure
+
+The directory should contain:
+
+- `file.png`, a PNG file if `format` is `"PNG"`.
+- `file.tiff`, a TIFF file if `format` is `"TIFF"`.
+- `file.jpg`, a JPEG file if `format` is `"JPEG"`.
+- `file.gif`, a GIF file if `format` is `"GIF"`.
+- `file.webp`, a WEBP file if `format` is `"WEBP"`.
+
+All formats are validated based on their magic numbers.

--- a/docs/specifications/image_file.Rmd
+++ b/docs/specifications/image_file.Rmd
@@ -29,7 +29,7 @@ cat("  This should be set to \"", as.character(.version), "\".", sep="")
 The directory should contain:
 
 - `file.png`, a PNG file if `format` is `"PNG"`.
-- `file.tiff`, a TIFF file if `format` is `"TIFF"`.
+- `file.tif`, a TIFF file if `format` is `"TIFF"`.
 - `file.jpg`, a JPEG file if `format` is `"JPEG"`.
 - `file.gif`, a GIF file if `format` is `"GIF"`.
 - `file.webp`, a WEBP file if `format` is `"WEBP"`.

--- a/docs/specifications/spatial_experiment.Rmd
+++ b/docs/specifications/spatial_experiment.Rmd
@@ -55,16 +55,26 @@ This file should contain a `spatial_experiment` group, which contains the follow
   This should have the same length as `image_samples`.
   The datatype should be representable by a UTF-8 encoded string.
   Image identifiers should be unique within the set of images associated with a given sample (as defined by `image_samples`).
-- `image_formats`, a 1-dimensional string dataset specifying the format for each image.
+```{r, results="asis", echo=FALSE}
+if (.version >= package_version("1.3")) {
+    cat('- `image_formats` (optional),')
+} else {
+    cat("- `image_formats`,")
+}
+```
+  a 1-dimensional string dataset specifying the format for each image.
   This should have the same length as `image_samples`.
   The datatype should be representable by a UTF-8 encoded string.
 ```{r, results="asis", echo=FALSE}
-if (.version >= package_version("1.3")) {
-    cat('  Values should be either `"PNG"`, `"TIFF"`, `"JPEG"`, `"WEBP"`, `"GIF"` or `"OTHER"`.')
-} else if (.version >= package_version("1.1")) {
+if (.version >= package_version("1.1")) {
     cat('  Values should be either `"PNG"`, `"TIFF"` or `"OTHER"`.')
 } else {
     cat('  Values should be either `"PNG"` or `"TIFF"`.')
+}
+```
+```{r, results="asis", echo=FALSE}
+if (.version >= package_version("1.3")) {
+    cat('  If `image_formats` is not present, all images are treated as if they had an `"OTHER"` format.')
 }
 ```
 - `image_scale_factors`, a 1-dimensional dataset containing the scaling factor for each image.
@@ -74,23 +84,7 @@ if (.version >= package_version("1.3")) {
 
 The number of images is determined from the length of `image_samples` in the `images/mapping.h5` file.
 ```{r, results="asis", echo=FALSE}
-if (.version >= package_version("1.3")) {
-    cat("Each image should be represented by a file or directory inside the `images` subdirectory, named after its positional index, e.g., `0` for the first image, `1` for the second image.
-The exact name is determined from `image_formats`:
-
-- For PNG images, a `.png` file extension should be added.
-  Thus, the full name of the file would look like `0.png` for the first image, `1.png` for the second image, and so on.
-- For TIFF images, a `.tif` file extension should be added.
-  Thus, the full name of the file would look like `0.tif` for the first image, `1.tif` for the second image, and so on.
-- For JPEG images, a `.jpg` file extension should be added.
-  Thus, the full name of the file would look like `0.jpg` for the first image, `1.jpg` for the second image, and so on.
-- For WEBP images, a `.webp` file extension should be added.
-  Thus, the full name of the file would look like `0.webp` for the first image, `1.webp` for the second image, and so on.
-- For GIF images, a `.gif` file extension should be added.
-  Thus, the full name of the file would look like `0.gif` for the first image, `1.gif` for the second image, and so on.
-- For OTHER images, the positional index is directly used as the directory name inside `images`.
-  This directory should contain a child object that satisfies the `IMAGE` interface.")
-} else if (.version >= package_version("1.1")) {
+if (.version >= package_version("1.1")) {
     cat("Each image should be represented by a file or directory inside the `images` subdirectory, named after its positional index, e.g., `0` for the first image, `1` for the second image.
 The exact name is determined from `image_formats`:
 

--- a/docs/specifications/spatial_experiment.Rmd
+++ b/docs/specifications/spatial_experiment.Rmd
@@ -59,7 +59,9 @@ This file should contain a `spatial_experiment` group, which contains the follow
   This should have the same length as `image_samples`.
   The datatype should be representable by a UTF-8 encoded string.
 ```{r, results="asis", echo=FALSE}
-if (.version >= package_version("1.1")) {
+if (.version >= package_version("1.3")) {
+    cat('  Values should be either `"PNG"`, `"TIFF"`, `"JPEG"`, `"WEBP"`, `"GIF"` or `"OTHER"`.')
+} else if (.version >= package_version("1.1")) {
     cat('  Values should be either `"PNG"`, `"TIFF"` or `"OTHER"`.')
 } else {
     cat('  Values should be either `"PNG"` or `"TIFF"`.')
@@ -72,7 +74,23 @@ if (.version >= package_version("1.1")) {
 
 The number of images is determined from the length of `image_samples` in the `images/mapping.h5` file.
 ```{r, results="asis", echo=FALSE}
-if (.version >= package_version("1.1")) {
+if (.version >= package_version("1.3")) {
+    cat("Each image should be represented by a file or directory inside the `images` subdirectory, named after its positional index, e.g., `0` for the first image, `1` for the second image.
+The exact name is determined from `image_formats`:
+
+- For PNG images, a `.png` file extension should be added.
+  Thus, the full name of the file would look like `0.png` for the first image, `1.png` for the second image, and so on.
+- For TIFF images, a `.tif` file extension should be added.
+  Thus, the full name of the file would look like `0.tif` for the first image, `1.tif` for the second image, and so on.
+- For JPEG images, a `.jpg` file extension should be added.
+  Thus, the full name of the file would look like `0.jpg` for the first image, `1.jpg` for the second image, and so on.
+- For WEBP images, a `.webp` file extension should be added.
+  Thus, the full name of the file would look like `0.webp` for the first image, `1.webp` for the second image, and so on.
+- For GIF images, a `.gif` file extension should be added.
+  Thus, the full name of the file would look like `0.gif` for the first image, `1.gif` for the second image, and so on.
+- For OTHER images, the positional index is directly used as the directory name inside `images`.
+  This directory should contain a child object that satisfies the `IMAGE` interface.")
+} else if (.version >= package_version("1.1")) {
     cat("Each image should be represented by a file or directory inside the `images` subdirectory, named after its positional index, e.g., `0` for the first image, `1` for the second image.
 The exact name is determined from `image_formats`:
 

--- a/include/takane/_satisfies_interface.hpp
+++ b/include/takane/_satisfies_interface.hpp
@@ -23,6 +23,7 @@ inline auto default_registry() {
     registry["SIMPLE_LIST"] = { "simple_list" };
     registry["DATA_FRAME"] = { "data_frame" };
     registry["SUMMARIZED_EXPERIMENT"] = { "summarized_experiment", "vcf_experiment" };
+    registry["IMAGE"] = { "image_file" };
     return registry;
 }
 

--- a/include/takane/_validate.hpp
+++ b/include/takane/_validate.hpp
@@ -39,6 +39,7 @@
 #include "bumpy_data_frame_array.hpp"
 #include "vcf_experiment.hpp"
 #include "delayed_array.hpp"
+#include "image_file.hpp"
 
 /**
  * @file _validate.hpp
@@ -86,6 +87,7 @@ inline auto default_registry() {
     registry["bumpy_data_frame_array"] = [](const std::filesystem::path& p, const ObjectMetadata& m, Options& o) { bumpy_data_frame_array::validate(p, m, o); };
     registry["vcf_experiment"] = [](const std::filesystem::path& p, const ObjectMetadata& m, Options& o) { vcf_experiment::validate(p, m, o); };
     registry["delayed_array"] = [](const std::filesystem::path& p, const ObjectMetadata& m, Options& o) { delayed_array::validate(p, m, o); };
+    registry["image_file"] = [](const std::filesystem::path& p, const ObjectMetadata& m, Options& o) { image_file::validate(p, m, o); };
     return registry;
 } 
 

--- a/include/takane/image_file.hpp
+++ b/include/takane/image_file.hpp
@@ -1,0 +1,121 @@
+#ifndef TAKANE_IMAGE_FILE_HPP
+#define TAKANE_IMAGE_FILE_HPP
+
+#include "utils_files.hpp"
+
+#include <filesystem>
+#include <stdexcept>
+#include <array>
+#include <string>
+
+/**
+ * @file image_file.hpp
+ * @brief Validation for standard image files.
+ */
+
+namespace takane {
+
+/**
+ * @namespace takane::image_file
+ * @brief Definitions for standard image files.
+ */
+namespace image_file {
+
+/**
+ * @cond
+ */
+namespace internal {
+
+// Factored out for re-use in spatial_experiment::internal::validate_image.
+inline void validate_png(const std::filesystem::path& path) {
+    // Magic number from http://www.libpng.org/pub/png/spec/1.2/png-1.2-pdg.html#PNG-file-signature
+    constexpr std::array<unsigned char, 8> expected { 137, 80, 78, 71, 13, 10, 26, 10 };
+    internal_files::check_signature<byteme::RawFileReader>(path, expected.data(), expected.size(), "PNG");
+}
+
+inline void validate_tiff(const std::filesystem::path& path) {
+    std::array<unsigned char, 4> observed{};
+    internal_files::extract_signature(path, observed.data(), observed.size());
+    // Magic numbers from https://en.wikipedia.org/wiki/Magic_number_(programming)
+    constexpr std::array<unsigned char, 4> iisig { 0x49, 0x49, 0x2A, 0x00 };
+    constexpr std::array<unsigned char, 4> mmsig { 0x4D, 0x4D, 0x00, 0x2A };
+    if (observed != iisig && observed != mmsig) {
+        throw std::runtime_error("incorrect TIFF file signature for '" + path.string() + "'");
+    }
+}
+
+}
+/**
+ * @endcond
+ */
+
+/**
+ * If `Options::image_file_strict_check` is provided, it is used to perform stricter checking of the image file contents. 
+ * By default, we don't look past the magic number to verify the files as this requires a dependency on heavy-duty libraries like, e.g., Magick.
+ *
+ * @param path Path to the directory containing the image file.
+ * @param metadata Metadata for the object, typically read from its `OBJECT` file.
+ * @param options Validation options.
+ */
+inline void validate(const std::filesystem::path& path, const ObjectMetadata& metadata, Options& options) {
+    const std::string type_name = "image_file"; // use a separate variable to avoid dangling reference warnings from GCC.
+    const auto& obj = internal_json::extract_typed_object_from_metadata(metadata.other, type_name);
+
+    const auto& vstring = internal_json::extract_string_from_typed_object(obj, "version", type_name);
+    auto version = ritsuko::parse_version_string(vstring.c_str(), vstring.size(), /* skip_patch = */ true);
+    if (version.major != 1) {
+        throw std::runtime_error("unsupported version string '" + vstring + "'");
+    }
+
+    const std::string format_name = "format";
+    const std::string& format = internal_json::extract_string(obj, format_name);
+    const std::string prefix = (path / "file").string();
+
+    if (format == "PNG") {
+        const std::filesystem::path ipath = prefix + ".png";
+        internal::validate_png(ipath);
+
+    } else if (format == "TIFF") {
+        const std::filesystem::path ipath = prefix + ".tif";
+        internal::validate_tiff(ipath);
+
+    } else if (format == "JPEG" && version.ge(1, 3, 0)) {
+        auto ipath = prefix + ".jpg";
+        // Common prefix of the JPEG-related magic numbers from https://en.wikipedia.org/wiki/List_of_file_signatures
+        constexpr std::array<unsigned char, 2> expected { 0xFF, 0xD8 };
+        internal_files::check_signature<byteme::RawFileReader>(ipath, expected.data(), expected.size(), "JPEG");
+
+    } else if (format == "GIF" && version.ge(1, 3, 0)) {
+        auto ipath = prefix + ".gif";
+        // Common prefix of the old and new magic numbers from https://en.wikipedia.org/wiki/GIF
+        constexpr std::array<unsigned char, 4> expected{ 0x47, 0x49, 0x46, 0x38 };
+        internal_files::check_signature<byteme::RawFileReader>(ipath, expected.data(), expected.size(), "GIF");
+
+    } else if (format == "WEBP" && version.ge(1, 3, 0)) {
+        auto ipath = prefix + ".webp";
+        std::array<unsigned char, 12> observed;
+        internal_files::extract_signature(ipath, observed.data(), observed.size());
+        constexpr std::array<unsigned char, 4> first4 { 0x52, 0x49, 0x46, 0x46 };
+        constexpr std::array<unsigned char, 4> last4 { 0x57, 0x45, 0x42, 0x50 };
+        std::array<unsigned char, 4> observed_first, observed_last;
+        std::copy_n(observed.begin(), 4, observed_first.begin());
+        std::copy_n(observed.begin() + 8, 4, observed_last.begin());
+        if (observed_first != first4 || observed_last != last4) {
+            throw std::runtime_error("incorrect WEBP file signature for '" + ipath + "'");
+        }
+
+    } else {
+        throw std::runtime_error("unsupported format '" + format + "'");
+    }
+
+    if (options.image_file_strict_check) {
+        options.image_file_strict_check(path, metadata, options);
+    }
+}
+
+}
+
+}
+
+#endif
+

--- a/include/takane/image_file.hpp
+++ b/include/takane/image_file.hpp
@@ -61,7 +61,8 @@ inline void validate(const std::filesystem::path& path, const ObjectMetadata& me
     const std::string type_name = "image_file"; // use a separate variable to avoid dangling reference warnings from GCC.
     const auto& obj = internal_json::extract_typed_object_from_metadata(metadata.other, type_name);
 
-    const auto& vstring = internal_json::extract_string_from_typed_object(obj, "version", type_name);
+    const std::string vname = "version";
+    const auto& vstring = internal_json::extract_string_from_typed_object(obj, vname, type_name);
     auto version = ritsuko::parse_version_string(vstring.c_str(), vstring.size(), /* skip_patch = */ true);
     if (version.major != 1) {
         throw std::runtime_error("unsupported version string '" + vstring + "'");

--- a/include/takane/image_file.hpp
+++ b/include/takane/image_file.hpp
@@ -79,19 +79,19 @@ inline void validate(const std::filesystem::path& path, const ObjectMetadata& me
         const std::filesystem::path ipath = prefix + ".tif";
         internal::validate_tiff(ipath);
 
-    } else if (format == "JPEG" && version.ge(1, 3, 0)) {
+    } else if (format == "JPEG") {
         auto ipath = prefix + ".jpg";
         // Common prefix of the JPEG-related magic numbers from https://en.wikipedia.org/wiki/List_of_file_signatures
         constexpr std::array<unsigned char, 2> expected { 0xFF, 0xD8 };
         internal_files::check_signature<byteme::RawFileReader>(ipath, expected.data(), expected.size(), "JPEG");
 
-    } else if (format == "GIF" && version.ge(1, 3, 0)) {
+    } else if (format == "GIF") {
         auto ipath = prefix + ".gif";
         // Common prefix of the old and new magic numbers from https://en.wikipedia.org/wiki/GIF
         constexpr std::array<unsigned char, 4> expected{ 0x47, 0x49, 0x46, 0x38 };
         internal_files::check_signature<byteme::RawFileReader>(ipath, expected.data(), expected.size(), "GIF");
 
-    } else if (format == "WEBP" && version.ge(1, 3, 0)) {
+    } else if (format == "WEBP") {
         auto ipath = prefix + ".webp";
         std::array<unsigned char, 12> observed;
         internal_files::extract_signature(ipath, observed.data(), observed.size());

--- a/include/takane/spatial_experiment.hpp
+++ b/include/takane/spatial_experiment.hpp
@@ -84,7 +84,7 @@ inline void validate_image(const std::filesystem::path& path, size_t i, const st
     if (format == "PNG") {
         ipath += ".png";
         // Magic number from http://www.libpng.org/pub/png/spec/1.2/png-1.2-pdg.html#PNG-file-signature
-        std::array<unsigned char, 8> expected { 137, 80, 78, 71, 13, 10, 26, 10 };
+        constexpr std::array<unsigned char, 8> expected { 137, 80, 78, 71, 13, 10, 26, 10 };
         internal_files::check_signature<byteme::RawFileReader>(ipath, expected.data(), expected.size(), "PNG");
 
     } else if (format == "TIFF") {
@@ -92,8 +92,8 @@ inline void validate_image(const std::filesystem::path& path, size_t i, const st
         std::array<unsigned char, 4> observed;
         internal_files::extract_signature(ipath, observed.data(), observed.size());
         // Magic numbers from https://en.wikipedia.org/wiki/Magic_number_(programming)
-        std::array<unsigned char, 4> iisig = { 0x49, 0x49, 0x2A, 0x00 };
-        std::array<unsigned char, 4> mmsig = { 0x4D, 0x4D, 0x00, 0x2A };
+        constexpr std::array<unsigned char, 4> iisig { 0x49, 0x49, 0x2A, 0x00 };
+        constexpr std::array<unsigned char, 4> mmsig { 0x4D, 0x4D, 0x00, 0x2A };
         if (observed != iisig && observed != mmsig) {
             throw std::runtime_error("incorrect TIFF file signature for '" + ipath.string() + "'");
         }
@@ -104,6 +104,31 @@ inline void validate_image(const std::filesystem::path& path, size_t i, const st
             throw std::runtime_error("object in '" + ipath.string() + "' should satisfy the 'IMAGE' interface");
         }
         ::takane::validate(ipath, imeta, options);
+
+    } else if (format == "JPEG" && version.ge(1, 3, 0)) {
+        ipath += ".jpg";
+        // Common prefix of the JPEG-related magic numbers from https://en.wikipedia.org/wiki/List_of_file_signatures
+        constexpr std::array<unsigned char, 2> expected { 0xFF, 0xD8 };
+        internal_files::check_signature<byteme::RawFileReader>(ipath, expected.data(), expected.size(), "JPEG");
+
+    } else if (format == "GIF" && version.ge(1, 3, 0)) {
+        ipath += ".gif";
+        // Common prefix of the old and new magic numbers from https://en.wikipedia.org/wiki/GIF
+        constexpr std::array<unsigned char, 4> expected{ 0x47, 0x49, 0x46, 0x38 };
+        internal_files::check_signature<byteme::RawFileReader>(ipath, expected.data(), expected.size(), "GIF");
+
+    } else if (format == "WEBP" && version.ge(1, 3, 0)) {
+        ipath += ".webp";
+        std::array<unsigned char, 12> observed;
+        internal_files::extract_signature(ipath, observed.data(), observed.size());
+        constexpr std::array<unsigned char, 4> first4 { 0x52, 0x49, 0x46, 0x46 };
+        constexpr std::array<unsigned char, 4> last4 { 0x57, 0x45, 0x42, 0x50 };
+        std::array<unsigned char, 4> observed_first, observed_last;
+        std::copy_n(observed.begin(), 4, observed_first.begin());
+        std::copy_n(observed.begin() + 8, 4, observed_last.begin());
+        if (observed_first != first4 || observed_last != last4) {
+            throw std::runtime_error("incorrect WEBP file signature for '" + ipath.string() + "'");
+        }
 
     } else {
         throw std::runtime_error("image format '" + format + "' is not currently supported");
@@ -209,7 +234,7 @@ inline void validate_images(const std::filesystem::path& path, size_t ncols, Opt
         throw std::runtime_error("failed to validate '" + mappath.string() + "'; " + std::string(e.what()));
     }
 
-    // Now validating the images themselves.
+    // Now validating the images themselves. 
     size_t num_images = image_formats.size();
     for (size_t i = 0; i < num_images; ++i) {
         validate_image(image_dir, i, image_formats[i], options, version);

--- a/include/takane/utils_public.hpp
+++ b/include/takane/utils_public.hpp
@@ -232,6 +232,14 @@ public:
      * Options to use for validating **chihaya** specifications in `delayed_array::validate()`.
      */
     chihaya::Options delayed_array_options;
+
+    /**
+     * Application-specific function to check the validity of an image file in `image_file::validate()`.
+     * This should accept a path to the directory containing the image file, the object metadata, and additional reading options.
+     * It should throw an error if the image file is not valid.
+     */
+    std::function<void(const std::filesystem::path&, const ObjectMetadata&, Options&)> image_file_strict_check;
+
 };
 
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -52,6 +52,7 @@ add_executable(
     src/bumpy_data_frame_array.cpp
     src/vcf_experiment.cpp
     src/delayed_array.cpp
+    src/image_file.cpp
     src/utils_compressed_list.cpp
     src/utils_bumpy_array.cpp
     src/utils_string.cpp

--- a/tests/src/image_file.cpp
+++ b/tests/src/image_file.cpp
@@ -1,0 +1,135 @@
+
+TEST_F(SpatialExperimentTest, ImageSignatures) {
+    takane::Options opt;
+    const ritsuko::Version ver(1, 0, 0);
+
+    {
+        initialize_directory(dir);
+        auto ipath = dir / "0.png";
+        {
+            std::ofstream ohandle(ipath);
+        }
+        expect_image_error("incomplete PNG file signature", dir, 0, "PNG", opt, ver);
+
+        {
+            std::ofstream ohandle(ipath);
+            ohandle << "chino-chan";
+        }
+        expect_image_error("incorrect PNG file signature", dir, 0, "PNG", opt, ver);
+
+        {
+            std::ofstream ohandle(ipath);
+            constexpr std::array<unsigned char, 8> stuff { 137, 80, 78, 71, 13, 10, 26, 10 };
+            ohandle.write(reinterpret_cast<const char*>(stuff.data()), stuff.size());
+        }
+        takane::spatial_experiment::internal::validate_image(dir, 0, "PNG", opt, ver);
+    }
+
+    {
+        initialize_directory(dir);
+        auto ipath = dir / "1.tif";
+        {
+            std::ofstream ohandle(ipath);
+        }
+        expect_image_error("too small", dir, 1, "TIFF", opt, ver);
+
+        {
+            std::ofstream ohandle(ipath);
+            ohandle << "chino-chan";
+        }
+        expect_image_error("incorrect TIFF file signature", dir, 1, "TIFF", opt, ver);
+
+        {
+            std::ofstream ohandle(ipath);
+            constexpr std::array<unsigned char, 4> stuff{ 0x49, 0x49, 0x2A, 0x00 };
+            ohandle.write(reinterpret_cast<const char*>(stuff.data()), stuff.size());
+        }
+        takane::spatial_experiment::internal::validate_image(dir, 1, "TIFF", opt, ver);
+
+        {
+            std::ofstream ohandle(ipath);
+            constexpr std::array<unsigned char, 4> stuff{ 0x4D, 0x4D, 0x00, 0x2A };
+            ohandle.write(reinterpret_cast<const char*>(stuff.data()), stuff.size());
+        }
+        takane::spatial_experiment::internal::validate_image(dir, 1, "TIFF", opt, ver);
+    }
+
+    const ritsuko::Version latestver(1, 3, 0);
+
+    {
+        initialize_directory(dir);
+        auto ipath = dir / "2.jpg";
+        {
+            std::ofstream ohandle(ipath);
+        }
+        expect_image_error("not currently supported", dir, 2, "JPEG", opt, ver);
+        expect_image_error("incomplete JPEG file signature", dir, 2, "JPEG", opt, latestver);
+
+        {
+            std::ofstream ohandle(ipath);
+            ohandle << "chino-chan";
+        }
+        expect_image_error("incorrect JPEG file signature", dir, 2, "JPEG", opt, latestver);
+
+        {
+            std::ofstream ohandle(ipath);
+            constexpr std::array<unsigned char, 4> stuff { 0xff, 0xd8, 0xff, 0xe1 };
+            ohandle.write(reinterpret_cast<const char*>(stuff.data()), stuff.size());
+        }
+        takane::spatial_experiment::internal::validate_image(dir, 2, "JPEG", opt, latestver);
+    }
+
+    {
+        initialize_directory(dir);
+        auto ipath = dir / "3.gif";
+        {
+            std::ofstream ohandle(ipath);
+        }
+        expect_image_error("not currently supported", dir, 3, "GIF", opt, ver);
+        expect_image_error("incomplete GIF file signature", dir, 3, "GIF", opt, latestver);
+
+        {
+            std::ofstream ohandle(ipath);
+            ohandle << "chino-chan";
+        }
+        expect_image_error("incorrect GIF file signature", dir, 3, "GIF", opt, latestver);
+
+        {
+            std::ofstream ohandle(ipath);
+            constexpr std::array<unsigned char, 4> stuff { 0x47, 0x49, 0x46, 0x38 };
+            ohandle.write(reinterpret_cast<const char*>(stuff.data()), stuff.size());
+        }
+        takane::spatial_experiment::internal::validate_image(dir, 3, "GIF", opt, latestver);
+    }
+
+    {
+        initialize_directory(dir);
+        auto ipath = dir / "4.webp";
+        {
+            std::ofstream ohandle(ipath);
+        }
+        expect_image_error("not currently supported", dir, 4, "WEBP", opt, ver);
+        expect_image_error("too small", dir, 4, "WEBP", opt, latestver);
+
+        {
+            std::ofstream ohandle(ipath);
+            ohandle << "kirima-syaro";
+        }
+        expect_image_error("incorrect WEBP file signature", dir, 4, "WEBP", opt, latestver);
+
+        {
+            std::ofstream ohandle(ipath);
+            constexpr std::array<unsigned char, 12> stuff { 0x52, 0x49, 0x46, 0x46, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 };
+            ohandle.write(reinterpret_cast<const char*>(stuff.data()), stuff.size());
+        }
+        expect_image_error("incorrect WEBP file signature", dir, 4, "WEBP", opt, latestver);
+
+        {
+            std::ofstream ohandle(ipath);
+            constexpr std::array<unsigned char, 12> stuff { 0x52, 0x49, 0x46, 0x46, 0x0, 0x0, 0x0, 0x0, 0x57, 0x45, 0x42, 0x50 };
+            ohandle.write(reinterpret_cast<const char*>(stuff.data()), stuff.size());
+        }
+        takane::spatial_experiment::internal::validate_image(dir, 4, "WEBP", opt, latestver);
+    }
+}
+

--- a/tests/src/image_file.cpp
+++ b/tests/src/image_file.cpp
@@ -1,135 +1,182 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
-TEST_F(SpatialExperimentTest, ImageSignatures) {
-    takane::Options opt;
-    const ritsuko::Version ver(1, 0, 0);
+#include "takane/image_file.hpp"
+#include "utils.h"
 
-    {
-        initialize_directory(dir);
-        auto ipath = dir / "0.png";
-        {
-            std::ofstream ohandle(ipath);
-        }
-        expect_image_error("incomplete PNG file signature", dir, 0, "PNG", opt, ver);
+#include <string>
+#include <vector>
+#include <filesystem>
+#include <stdexcept>
 
-        {
-            std::ofstream ohandle(ipath);
-            ohandle << "chino-chan";
-        }
-        expect_image_error("incorrect PNG file signature", dir, 0, "PNG", opt, ver);
-
-        {
-            std::ofstream ohandle(ipath);
-            constexpr std::array<unsigned char, 8> stuff { 137, 80, 78, 71, 13, 10, 26, 10 };
-            ohandle.write(reinterpret_cast<const char*>(stuff.data()), stuff.size());
-        }
-        takane::spatial_experiment::internal::validate_image(dir, 0, "PNG", opt, ver);
+struct ImageFileTest : public ::testing::Test {
+    ImageFileTest() {
+        dir = "TEST_image_file";
+        name = "image_file";
     }
 
-    {
-        initialize_directory(dir);
-        auto ipath = dir / "1.tif";
-        {
-            std::ofstream ohandle(ipath);
-        }
-        expect_image_error("too small", dir, 1, "TIFF", opt, ver);
+    std::filesystem::path dir;
+    std::string name;
 
-        {
-            std::ofstream ohandle(ipath);
-            ohandle << "chino-chan";
-        }
-        expect_image_error("incorrect TIFF file signature", dir, 1, "TIFF", opt, ver);
-
-        {
-            std::ofstream ohandle(ipath);
-            constexpr std::array<unsigned char, 4> stuff{ 0x49, 0x49, 0x2A, 0x00 };
-            ohandle.write(reinterpret_cast<const char*>(stuff.data()), stuff.size());
-        }
-        takane::spatial_experiment::internal::validate_image(dir, 1, "TIFF", opt, ver);
-
-        {
-            std::ofstream ohandle(ipath);
-            constexpr std::array<unsigned char, 4> stuff{ 0x4D, 0x4D, 0x00, 0x2A };
-            ohandle.write(reinterpret_cast<const char*>(stuff.data()), stuff.size());
-        }
-        takane::spatial_experiment::internal::validate_image(dir, 1, "TIFF", opt, ver);
+    template<typename ... Args_>
+    void expect_error(const std::string& msg, Args_&& ... args) {
+        expect_validation_error(dir, msg, std::forward<Args_>(args)...);
     }
 
-    const ritsuko::Version latestver(1, 3, 0);
-
-    {
-        initialize_directory(dir);
-        auto ipath = dir / "2.jpg";
-        {
-            std::ofstream ohandle(ipath);
-        }
-        expect_image_error("not currently supported", dir, 2, "JPEG", opt, ver);
-        expect_image_error("incomplete JPEG file signature", dir, 2, "JPEG", opt, latestver);
-
-        {
-            std::ofstream ohandle(ipath);
-            ohandle << "chino-chan";
-        }
-        expect_image_error("incorrect JPEG file signature", dir, 2, "JPEG", opt, latestver);
-
-        {
-            std::ofstream ohandle(ipath);
-            constexpr std::array<unsigned char, 4> stuff { 0xff, 0xd8, 0xff, 0xe1 };
-            ohandle.write(reinterpret_cast<const char*>(stuff.data()), stuff.size());
-        }
-        takane::spatial_experiment::internal::validate_image(dir, 2, "JPEG", opt, latestver);
+    void dump_object_file(const std::string& format) {
+        auto obody = "{ \"type\": \"image_file\", \"image_file\": { \"version\": \"1.0\", \"format\": \"" + format + "\" } }";
+        auto opath = dir / "OBJECT"; 
+        byteme::RawFileWriter writer(opath.c_str(), {});
+        writer.write(reinterpret_cast<const unsigned char*>(obody.c_str()), obody.size());
     }
+};
 
-    {
-        initialize_directory(dir);
-        auto ipath = dir / "3.gif";
-        {
-            std::ofstream ohandle(ipath);
-        }
-        expect_image_error("not currently supported", dir, 3, "GIF", opt, ver);
-        expect_image_error("incomplete GIF file signature", dir, 3, "GIF", opt, latestver);
+TEST_F(ImageFileTest, Basic) {
+    initialize_directory_simple(dir, name, "2.0");
+    expect_error("unsupported version");
 
-        {
-            std::ofstream ohandle(ipath);
-            ohandle << "chino-chan";
-        }
-        expect_image_error("incorrect GIF file signature", dir, 3, "GIF", opt, latestver);
-
-        {
-            std::ofstream ohandle(ipath);
-            constexpr std::array<unsigned char, 4> stuff { 0x47, 0x49, 0x46, 0x38 };
-            ohandle.write(reinterpret_cast<const char*>(stuff.data()), stuff.size());
-        }
-        takane::spatial_experiment::internal::validate_image(dir, 3, "GIF", opt, latestver);
-    }
-
-    {
-        initialize_directory(dir);
-        auto ipath = dir / "4.webp";
-        {
-            std::ofstream ohandle(ipath);
-        }
-        expect_image_error("not currently supported", dir, 4, "WEBP", opt, ver);
-        expect_image_error("too small", dir, 4, "WEBP", opt, latestver);
-
-        {
-            std::ofstream ohandle(ipath);
-            ohandle << "kirima-syaro";
-        }
-        expect_image_error("incorrect WEBP file signature", dir, 4, "WEBP", opt, latestver);
-
-        {
-            std::ofstream ohandle(ipath);
-            constexpr std::array<unsigned char, 12> stuff { 0x52, 0x49, 0x46, 0x46, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 };
-            ohandle.write(reinterpret_cast<const char*>(stuff.data()), stuff.size());
-        }
-        expect_image_error("incorrect WEBP file signature", dir, 4, "WEBP", opt, latestver);
-
-        {
-            std::ofstream ohandle(ipath);
-            constexpr std::array<unsigned char, 12> stuff { 0x52, 0x49, 0x46, 0x46, 0x0, 0x0, 0x0, 0x0, 0x57, 0x45, 0x42, 0x50 };
-            ohandle.write(reinterpret_cast<const char*>(stuff.data()), stuff.size());
-        }
-        takane::spatial_experiment::internal::validate_image(dir, 4, "WEBP", opt, latestver);
-    }
+    initialize_directory(dir);
+    dump_object_file("FOO");
+    expect_error("unsupported format");
 }
 
+TEST_F(ImageFileTest, Png) {
+    initialize_directory(dir);
+    dump_object_file("PNG");
+
+    auto ipath = dir / "file.png";
+    {
+        std::ofstream ohandle(ipath);
+    }
+    expect_error("incomplete PNG file signature");
+
+    {
+        std::ofstream ohandle(ipath);
+        ohandle << "chino-chan";
+    }
+    expect_error("incorrect PNG file signature");
+
+    {
+        std::ofstream ohandle(ipath);
+        constexpr std::array<unsigned char, 8> stuff { 137, 80, 78, 71, 13, 10, 26, 10 };
+        ohandle.write(reinterpret_cast<const char*>(stuff.data()), stuff.size());
+    }
+    test_validate(dir);
+
+    // Adding a strict check.
+    takane::Options opt;
+    opt.image_file_strict_check = [&](const std::filesystem::path&, const takane::ObjectMetadata&, takane::Options&) -> void {
+        throw std::runtime_error("FOOBAR");
+    };
+    expect_validation_error(dir, "FOOBAR", opt);
+}
+
+TEST_F(ImageFileTest, Tiff) {
+    initialize_directory(dir);
+    dump_object_file("TIFF");
+
+    auto ipath = dir / "file.tif";
+    {
+        std::ofstream ohandle(ipath);
+    }
+    expect_error("too small");
+
+    {
+        std::ofstream ohandle(ipath);
+        ohandle << "chino-chan";
+    }
+    expect_error("incorrect TIFF file signature");
+
+    {
+        std::ofstream ohandle(ipath);
+        constexpr std::array<unsigned char, 4> stuff{ 0x49, 0x49, 0x2A, 0x00 };
+        ohandle.write(reinterpret_cast<const char*>(stuff.data()), stuff.size());
+    }
+    test_validate(dir);
+
+    {
+        std::ofstream ohandle(ipath);
+        constexpr std::array<unsigned char, 4> stuff{ 0x4D, 0x4D, 0x00, 0x2A };
+        ohandle.write(reinterpret_cast<const char*>(stuff.data()), stuff.size());
+    }
+    test_validate(dir);
+}
+
+TEST_F(ImageFileTest, Jpeg) {
+    initialize_directory(dir);
+    dump_object_file("JPEG");
+
+    auto ipath = dir / "file.jpg";
+    {
+        std::ofstream ohandle(ipath);
+    }
+    expect_error("incomplete JPEG file signature");
+
+    {
+        std::ofstream ohandle(ipath);
+        ohandle << "chino-chan";
+    }
+    expect_error("incorrect JPEG file signature");
+
+    {
+        std::ofstream ohandle(ipath);
+        constexpr std::array<unsigned char, 4> stuff { 0xff, 0xd8, 0xff, 0xe1 };
+        ohandle.write(reinterpret_cast<const char*>(stuff.data()), stuff.size());
+    }
+    test_validate(dir);
+}
+
+TEST_F(ImageFileTest, Gif) {
+    initialize_directory(dir);
+    dump_object_file("GIF");
+
+    auto ipath = dir / "file.gif";
+    {
+        std::ofstream ohandle(ipath);
+    }
+    expect_error("incomplete GIF file signature");
+
+    {
+        std::ofstream ohandle(ipath);
+        ohandle << "chino-chan";
+    }
+    expect_error("incorrect GIF file signature");
+
+    {
+        std::ofstream ohandle(ipath);
+        constexpr std::array<unsigned char, 4> stuff { 0x47, 0x49, 0x46, 0x38 };
+        ohandle.write(reinterpret_cast<const char*>(stuff.data()), stuff.size());
+    }
+    test_validate(dir);
+}
+
+TEST_F(ImageFileTest, Webp) {
+    initialize_directory(dir);
+    dump_object_file("WEBP");
+
+    auto ipath = dir / "file.webp";
+    {
+        std::ofstream ohandle(ipath);
+    }
+    expect_error("too small");
+
+    {
+        std::ofstream ohandle(ipath);
+        ohandle << "kirima-syaro";
+    }
+    expect_error("incorrect WEBP file signature");
+
+    {
+        std::ofstream ohandle(ipath);
+        constexpr std::array<unsigned char, 12> stuff { 0x52, 0x49, 0x46, 0x46, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 };
+        ohandle.write(reinterpret_cast<const char*>(stuff.data()), stuff.size());
+    }
+    expect_error("incorrect WEBP file signature");
+
+    {
+        std::ofstream ohandle(ipath);
+        constexpr std::array<unsigned char, 12> stuff { 0x52, 0x49, 0x46, 0x46, 0x0, 0x0, 0x0, 0x0, 0x57, 0x45, 0x42, 0x50 };
+        ohandle.write(reinterpret_cast<const char*>(stuff.data()), stuff.size());
+    }
+    test_validate(dir);
+}

--- a/tests/src/spatial_experiment.cpp
+++ b/tests/src/spatial_experiment.cpp
@@ -384,148 +384,36 @@ TEST_F(SpatialExperimentTest, OtherImageFormats) {
     test_validate(dir, vopt);
 }
 
-template<typename ... Args_>
-static void expect_image_error(const std::string& msg, Args_&& ... args) {
-    EXPECT_ANY_THROW({
-        try {
-            takane::spatial_experiment::internal::validate_image(std::forward<Args_>(args)...);
-        } catch (std::exception& e) {
-            EXPECT_THAT(e.what(), ::testing::HasSubstr(msg));
-            throw;
-        }
-    });
-}
+TEST_F(SpatialExperimentTest, NoImageFormats) {
+    spatial_experiment::Options options(20, 19);
+    options.num_samples = 2;
+    options.num_images_per_sample = 7;
+    options.specify_format = false;
+    spatial_experiment::mock(dir, options);
 
-TEST_F(SpatialExperimentTest, ImageSignatures) {
-    takane::Options opt;
-    const ritsuko::Version ver(1, 0, 0);
+    expect_error("image_formats");
 
+    // Bumping the version so we actually get support for missing image formats.
     {
-        initialize_directory(dir);
-        auto ipath = dir / "0.png";
-        {
-            std::ofstream ohandle(ipath);
-        }
-        expect_image_error("incomplete PNG file signature", dir, 0, "PNG", opt, ver);
-
-        {
-            std::ofstream ohandle(ipath);
-            ohandle << "chino-chan";
-        }
-        expect_image_error("incorrect PNG file signature", dir, 0, "PNG", opt, ver);
-
-        {
-            std::ofstream ohandle(ipath);
-            constexpr std::array<unsigned char, 8> stuff { 137, 80, 78, 71, 13, 10, 26, 10 };
-            ohandle.write(reinterpret_cast<const char*>(stuff.data()), stuff.size());
-        }
-        takane::spatial_experiment::internal::validate_image(dir, 0, "PNG", opt, ver);
+        auto opath = dir / "OBJECT";
+        auto parsed = millijson::parse_file(opath.c_str(), {});
+        auto& remap = reinterpret_cast<millijson::Object*>(parsed.get())->value();
+        remap["type"] = std::shared_ptr<millijson::Base>(new millijson::String("spatial_experiment"));
+        spatial_experiment::add_object_metadata(parsed.get(), "1.3");
+        json_utils::dump(parsed.get(), opath);
     }
+    test_validate(dir);
 
+    // Latest version also works in the presence of image_formats.
+    options.specify_format = true;
+    spatial_experiment::mock(dir, options);
     {
-        initialize_directory(dir);
-        auto ipath = dir / "1.tif";
-        {
-            std::ofstream ohandle(ipath);
-        }
-        expect_image_error("too small", dir, 1, "TIFF", opt, ver);
-
-        {
-            std::ofstream ohandle(ipath);
-            ohandle << "chino-chan";
-        }
-        expect_image_error("incorrect TIFF file signature", dir, 1, "TIFF", opt, ver);
-
-        {
-            std::ofstream ohandle(ipath);
-            constexpr std::array<unsigned char, 4> stuff{ 0x49, 0x49, 0x2A, 0x00 };
-            ohandle.write(reinterpret_cast<const char*>(stuff.data()), stuff.size());
-        }
-        takane::spatial_experiment::internal::validate_image(dir, 1, "TIFF", opt, ver);
-
-        {
-            std::ofstream ohandle(ipath);
-            constexpr std::array<unsigned char, 4> stuff{ 0x4D, 0x4D, 0x00, 0x2A };
-            ohandle.write(reinterpret_cast<const char*>(stuff.data()), stuff.size());
-        }
-        takane::spatial_experiment::internal::validate_image(dir, 1, "TIFF", opt, ver);
+        auto opath = dir / "OBJECT";
+        auto parsed = millijson::parse_file(opath.c_str(), {});
+        auto& remap = reinterpret_cast<millijson::Object*>(parsed.get())->value();
+        remap["type"] = std::shared_ptr<millijson::Base>(new millijson::String("spatial_experiment"));
+        spatial_experiment::add_object_metadata(parsed.get(), "1.3");
+        json_utils::dump(parsed.get(), opath);
     }
-
-    const ritsuko::Version latestver(1, 3, 0);
-
-    {
-        initialize_directory(dir);
-        auto ipath = dir / "2.jpg";
-        {
-            std::ofstream ohandle(ipath);
-        }
-        expect_image_error("not currently supported", dir, 2, "JPEG", opt, ver);
-        expect_image_error("incomplete JPEG file signature", dir, 2, "JPEG", opt, latestver);
-
-        {
-            std::ofstream ohandle(ipath);
-            ohandle << "chino-chan";
-        }
-        expect_image_error("incorrect JPEG file signature", dir, 2, "JPEG", opt, latestver);
-
-        {
-            std::ofstream ohandle(ipath);
-            constexpr std::array<unsigned char, 4> stuff { 0xff, 0xd8, 0xff, 0xe1 };
-            ohandle.write(reinterpret_cast<const char*>(stuff.data()), stuff.size());
-        }
-        takane::spatial_experiment::internal::validate_image(dir, 2, "JPEG", opt, latestver);
-    }
-
-    {
-        initialize_directory(dir);
-        auto ipath = dir / "3.gif";
-        {
-            std::ofstream ohandle(ipath);
-        }
-        expect_image_error("not currently supported", dir, 3, "GIF", opt, ver);
-        expect_image_error("incomplete GIF file signature", dir, 3, "GIF", opt, latestver);
-
-        {
-            std::ofstream ohandle(ipath);
-            ohandle << "chino-chan";
-        }
-        expect_image_error("incorrect GIF file signature", dir, 3, "GIF", opt, latestver);
-
-        {
-            std::ofstream ohandle(ipath);
-            constexpr std::array<unsigned char, 4> stuff { 0x47, 0x49, 0x46, 0x38 };
-            ohandle.write(reinterpret_cast<const char*>(stuff.data()), stuff.size());
-        }
-        takane::spatial_experiment::internal::validate_image(dir, 3, "GIF", opt, latestver);
-    }
-
-    {
-        initialize_directory(dir);
-        auto ipath = dir / "4.webp";
-        {
-            std::ofstream ohandle(ipath);
-        }
-        expect_image_error("not currently supported", dir, 4, "WEBP", opt, ver);
-        expect_image_error("too small", dir, 4, "WEBP", opt, latestver);
-
-        {
-            std::ofstream ohandle(ipath);
-            ohandle << "kirima-syaro";
-        }
-        expect_image_error("incorrect WEBP file signature", dir, 4, "WEBP", opt, latestver);
-
-        {
-            std::ofstream ohandle(ipath);
-            constexpr std::array<unsigned char, 12> stuff { 0x52, 0x49, 0x46, 0x46, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 };
-            ohandle.write(reinterpret_cast<const char*>(stuff.data()), stuff.size());
-        }
-        expect_image_error("incorrect WEBP file signature", dir, 4, "WEBP", opt, latestver);
-
-        {
-            std::ofstream ohandle(ipath);
-            constexpr std::array<unsigned char, 12> stuff { 0x52, 0x49, 0x46, 0x46, 0x0, 0x0, 0x0, 0x0, 0x57, 0x45, 0x42, 0x50 };
-            ohandle.write(reinterpret_cast<const char*>(stuff.data()), stuff.size());
-        }
-        takane::spatial_experiment::internal::validate_image(dir, 4, "WEBP", opt, latestver);
-    }
+    test_validate(dir);
 }

--- a/tests/src/spatial_experiment.cpp
+++ b/tests/src/spatial_experiment.cpp
@@ -4,6 +4,8 @@
 #include "spatial_experiment.h"
 #include "utils.h"
 
+#include "takane/spatial_experiment.hpp"
+
 #include <string>
 #include <vector>
 #include <filesystem>
@@ -159,6 +161,19 @@ TEST_F(SpatialExperimentTest, NoImages) {
     }
 
     test_validate(dir); 
+}
+
+TEST_F(SpatialExperimentTest, ExtraImages) {
+    spatial_experiment::Options options(20, 19);
+    options.num_samples = 2;
+    options.num_images_per_sample = 1;
+    spatial_experiment::mock(dir, options);
+
+    {
+        auto ipath = dir / "images" / "2.tif";
+        std::ofstream ohandle(ipath);
+    }
+    expect_error("more objects than expected");
 }
 
 TEST_F(SpatialExperimentTest, ImageSamples) {
@@ -369,48 +384,148 @@ TEST_F(SpatialExperimentTest, OtherImageFormats) {
     test_validate(dir, vopt);
 }
 
-TEST_F(SpatialExperimentTest, ImageSignature) {
-    spatial_experiment::Options options(20, 19);
-    options.num_samples = 1;
-    options.num_images_per_sample = 2;
-    spatial_experiment::mock(dir, options);
-    test_validate(dir); 
+template<typename ... Args_>
+static void expect_image_error(const std::string& msg, Args_&& ... args) {
+    EXPECT_ANY_THROW({
+        try {
+            takane::spatial_experiment::internal::validate_image(std::forward<Args_>(args)...);
+        } catch (std::exception& e) {
+            EXPECT_THAT(e.what(), ::testing::HasSubstr(msg));
+            throw;
+        }
+    });
+}
 
-    // Overriding each image.
+TEST_F(SpatialExperimentTest, ImageSignatures) {
+    takane::Options opt;
+    const ritsuko::Version ver(1, 0, 0);
+
     {
-        auto ipath = dir / "images" / "0.png";
+        initialize_directory(dir);
+        auto ipath = dir / "0.png";
         {
             std::ofstream ohandle(ipath);
         }
-        expect_error("incomplete PNG file signature");
+        expect_image_error("incomplete PNG file signature", dir, 0, "PNG", opt, ver);
 
         {
             std::ofstream ohandle(ipath);
             ohandle << "chino-chan";
         }
-        expect_error("incorrect PNG file signature");
+        expect_image_error("incorrect PNG file signature", dir, 0, "PNG", opt, ver);
+
+        {
+            std::ofstream ohandle(ipath);
+            constexpr std::array<unsigned char, 8> stuff { 137, 80, 78, 71, 13, 10, 26, 10 };
+            ohandle.write(reinterpret_cast<const char*>(stuff.data()), stuff.size());
+        }
+        takane::spatial_experiment::internal::validate_image(dir, 0, "PNG", opt, ver);
     }
 
-    spatial_experiment::mock(dir, options);
     {
-        auto ipath = dir / "images" / "1.tif";
+        initialize_directory(dir);
+        auto ipath = dir / "1.tif";
         {
             std::ofstream ohandle(ipath);
         }
-        expect_error("too small");
+        expect_image_error("too small", dir, 1, "TIFF", opt, ver);
 
         {
             std::ofstream ohandle(ipath);
             ohandle << "chino-chan";
         }
-        expect_error("incorrect TIFF file signature");
+        expect_image_error("incorrect TIFF file signature", dir, 1, "TIFF", opt, ver);
+
+        {
+            std::ofstream ohandle(ipath);
+            constexpr std::array<unsigned char, 4> stuff{ 0x49, 0x49, 0x2A, 0x00 };
+            ohandle.write(reinterpret_cast<const char*>(stuff.data()), stuff.size());
+        }
+        takane::spatial_experiment::internal::validate_image(dir, 1, "TIFF", opt, ver);
+
+        {
+            std::ofstream ohandle(ipath);
+            constexpr std::array<unsigned char, 4> stuff{ 0x4D, 0x4D, 0x00, 0x2A };
+            ohandle.write(reinterpret_cast<const char*>(stuff.data()), stuff.size());
+        }
+        takane::spatial_experiment::internal::validate_image(dir, 1, "TIFF", opt, ver);
     }
 
-    // Replacing an image.
-    spatial_experiment::mock(dir, options);
+    const ritsuko::Version latestver(1, 3, 0);
+
     {
-        auto ipath = dir / "images" / "2.tif";
-        std::ofstream ohandle(ipath);
+        initialize_directory(dir);
+        auto ipath = dir / "2.jpg";
+        {
+            std::ofstream ohandle(ipath);
+        }
+        expect_image_error("not currently supported", dir, 2, "JPEG", opt, ver);
+        expect_image_error("incomplete JPEG file signature", dir, 2, "JPEG", opt, latestver);
+
+        {
+            std::ofstream ohandle(ipath);
+            ohandle << "chino-chan";
+        }
+        expect_image_error("incorrect JPEG file signature", dir, 2, "JPEG", opt, latestver);
+
+        {
+            std::ofstream ohandle(ipath);
+            constexpr std::array<unsigned char, 4> stuff { 0xff, 0xd8, 0xff, 0xe1 };
+            ohandle.write(reinterpret_cast<const char*>(stuff.data()), stuff.size());
+        }
+        takane::spatial_experiment::internal::validate_image(dir, 2, "JPEG", opt, latestver);
     }
-    expect_error("more objects than expected");
+
+    {
+        initialize_directory(dir);
+        auto ipath = dir / "3.gif";
+        {
+            std::ofstream ohandle(ipath);
+        }
+        expect_image_error("not currently supported", dir, 3, "GIF", opt, ver);
+        expect_image_error("incomplete GIF file signature", dir, 3, "GIF", opt, latestver);
+
+        {
+            std::ofstream ohandle(ipath);
+            ohandle << "chino-chan";
+        }
+        expect_image_error("incorrect GIF file signature", dir, 3, "GIF", opt, latestver);
+
+        {
+            std::ofstream ohandle(ipath);
+            constexpr std::array<unsigned char, 4> stuff { 0x47, 0x49, 0x46, 0x38 };
+            ohandle.write(reinterpret_cast<const char*>(stuff.data()), stuff.size());
+        }
+        takane::spatial_experiment::internal::validate_image(dir, 3, "GIF", opt, latestver);
+    }
+
+    {
+        initialize_directory(dir);
+        auto ipath = dir / "4.webp";
+        {
+            std::ofstream ohandle(ipath);
+        }
+        expect_image_error("not currently supported", dir, 4, "WEBP", opt, ver);
+        expect_image_error("too small", dir, 4, "WEBP", opt, latestver);
+
+        {
+            std::ofstream ohandle(ipath);
+            ohandle << "kirima-syaro";
+        }
+        expect_image_error("incorrect WEBP file signature", dir, 4, "WEBP", opt, latestver);
+
+        {
+            std::ofstream ohandle(ipath);
+            constexpr std::array<unsigned char, 12> stuff { 0x52, 0x49, 0x46, 0x46, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0 };
+            ohandle.write(reinterpret_cast<const char*>(stuff.data()), stuff.size());
+        }
+        expect_image_error("incorrect WEBP file signature", dir, 4, "WEBP", opt, latestver);
+
+        {
+            std::ofstream ohandle(ipath);
+            constexpr std::array<unsigned char, 12> stuff { 0x52, 0x49, 0x46, 0x46, 0x0, 0x0, 0x0, 0x0, 0x57, 0x45, 0x42, 0x50 };
+            ohandle.write(reinterpret_cast<const char*>(stuff.data()), stuff.size());
+        }
+        takane::spatial_experiment::internal::validate_image(dir, 4, "WEBP", opt, latestver);
+    }
 }


### PR DESCRIPTION
This includes PNG and TIFF, as well as JPEG, GIF and WEBP. This satisfies the
IMAGE interface so we can use it as nested objects for a spatial_experiment.

We also update spatial_experiment to allow the image_format HDF5 dataset to be
optional. If it's not present, we can assume that all images are in the "OTHER"
format, i.e., nested takane objects that satisfy the IMAGE interface. This is
simpler and more flexible rather than requiring hard-coding of image formats in
the spatial_experiment spec. (Probably should have done this in the first
place, given that the previous artificer spec took the same approach.)
